### PR TITLE
fix-shared-channel

### DIFF
--- a/lib/senrigan/adapter.rb
+++ b/lib/senrigan/adapter.rb
@@ -70,7 +70,7 @@ module Senrigan
         data =
           case channel_id.first
           when 'C'
-            resp = @client.channels_info(
+            resp = @client.conversations_info(
               channel: channel_id
             )
             resp['channel']


### PR DESCRIPTION
`channels_info` でも `conversations_info` でもchannelオブジェクトが取得できる点では同じようなので、全チャンネルを取得できる `conversations_info` に変更しました。

動作確認環境
ruby 2.6.3
macOS High Sierra 10.13.6
